### PR TITLE
ADX-312 Create a nav bar at the top of the config pages.

### DIFF
--- a/ckanext/dhis2harvester/public/dhis2_harvester_source_form.css
+++ b/ckanext/dhis2harvester/public/dhis2_harvester_source_form.css
@@ -225,3 +225,17 @@
   position: relative;
   top: 1px;
 }
+
+.formnav-stages{
+  margin-bottom: 50px;
+}
+
+.formnav-stages i {
+  margin-left: 15px;
+  font-weight: bold;
+  font-size: 120%;
+}
+
+.formnav-stages button{
+  border: none;
+}

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new.html
@@ -5,14 +5,17 @@
 
 {% block form_content %}
 
-
 <form id="source-new" class="dhis2-source-new form-horizontal dataset-form {{ h.bootstrap_version() }}" method="post" >
+
+  {% set stage_2_denied = not data.dhis2_auth_token %}
+  {% set stage_3_denied = not data.dhis2_auth_token or not data.selected_pivot_tables %}
+  {% set stage_4_denied = not data.dhis2_auth_token or not data.selected_pivot_tables or not data.column_values %}
 
   <div class="formnav-stages row">
     <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_1' %}btn-primary{% endif %}" type="submit" name="action" value="back.pivot_table_new_1">{{_('DHIS2 Connection')}} <i class="fa fa-angle-right"></i></button>
-    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_2' %}btn-primary{% endif %}" {% if not data.pivot_tables %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_2">{{_('Pivot Tables')}} <i class="fa fa-angle-right"></i></button>
-    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_3' %}btn-primary{% endif %}" {% if not data.column_values or not data.pivot_tables %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_3">{{_('Column Configuration')}} <i class="fa fa-angle-right"></i></button>
-    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_4' %}btn-primary{% endif %}" type="submit" name="action" value="back.pivot_table_new_4">{{_('Harvest Details')}}</button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_2' %}btn-primary{% endif %}" {% if stage_2_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_2">{{_('Pivot Tables')}} <i class="fa fa-angle-right"></i></button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_3' %}btn-primary{% endif %}" {% if stage_3_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_3">{{_('Column Configuration')}} <i class="fa fa-angle-right"></i></button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_4' %}btn-primary{% endif %}" {% if stage_4_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_4">{{_('Harvest Details')}}</button>
   </div>
 
   {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
@@ -29,14 +32,11 @@
   {% set show_organizations_selector = organizations_available and (user_is_sysadmin or dataset_is_draft) %}
   {% set selected_org = data.owner_org if data.owner_org else organizations_available[0].value %}
 
-
   {% include 'source/pivot_table_data.html' %}
   {% include 'source/dhis2_credentials.html' %}
   {% include 'source/pivot_table_new_2.html' %}
   {% include 'source/pivot_table_new_3.html' %}
   {% include 'source/pivot_table_new_4.html' %}
-
-
 
   {% if data.get('id', None) and h.check_access('harvest_source_delete', {'id': data.id}) and data.get('state', 'none') == 'deleted' %}
     <div class="control-group">

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new.html
@@ -2,8 +2,19 @@
 {% import 'macros/form.html' as form %}
 {% resource 'harvest-extra-field/main' %}
 
+
 {% block form_content %}
+
+
 <form id="source-new" class="dhis2-source-new form-horizontal dataset-form {{ h.bootstrap_version() }}" method="post" >
+
+  <div class="formnav-stages row">
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_1' %}btn-primary{% endif %}" type="submit" name="action" value="back.pivot_table_new_1">{{_('DHIS2 Connection')}} <i class="fa fa-angle-right"></i></button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_2' %}btn-primary{% endif %}" {% if not data.pivot_tables %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_2">{{_('Pivot Tables')}} <i class="fa fa-angle-right"></i></button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_3' %}btn-primary{% endif %}" {% if not data.column_values or not data.pivot_tables %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_3">{{_('Column Configuration')}} <i class="fa fa-angle-right"></i></button>
+    <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_4' %}btn-primary{% endif %}" type="submit" name="action" value="back.pivot_table_new_4">{{_('Harvest Details')}}</button>
+  </div>
+
   {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
 
   {# if we have a default group then this wants remembering #}

--- a/ckanext/dhis2harvester/ui_blueprint.py
+++ b/ckanext/dhis2harvester/ui_blueprint.py
@@ -338,56 +338,58 @@ def __data_initialization(edit=False):
                                  zip(pivot_table_ids, pivot_table_types)]
         data['selected_pivot_tables'] = selected_pivot_tables
         log.debug("Selected pivot tables: " + str(selected_pivot_tables))
+    elif not pivot_table_ids:
+        pivot_table_ids = [x['id'] for x in data['selected_pivot_tables']]
 
-        # pivot table columns
-        pivot_table_columns_ = {}
-        for pt_id in pivot_table_ids:
-            columns_ = dhis2_conn_.get_pivot_table_columns(pt_id)
-            pt_columns_ = [{'value': c['id'], 'text': c['name']} for c in columns_]
-            pivot_table_columns_[pt_id] = pt_columns_
-        data['pivot_table_columns'] = pivot_table_columns_
-        log.debug("Pivot table columns: " + str(pivot_table_columns_))
+    # pivot table columns
+    pivot_table_columns_ = {}
+    for pt_id in pivot_table_ids:
+        columns_ = dhis2_conn_.get_pivot_table_columns(pt_id)
+        pt_columns_ = [{'value': c['id'], 'text': c['name']} for c in columns_]
+        pivot_table_columns_[pt_id] = pt_columns_
+    data['pivot_table_columns'] = pivot_table_columns_
+    log.debug("Pivot table columns: " + str(pivot_table_columns_))
 
-        # selected column values
-        column_values = []
-        for pt in selected_pivot_tables:
-            pt_id = pt['id']
-            pt_type = pt['type']
-            pt_column_values_ = {
-                'id': pt_id,
-            }
-            columns_ = defaultdict(dict)
-            for k in data:
-                if k.startswith("target_column_{}".format(pt_id)):
-                    c_id_ = k.split('_')[-1]
-                    target_column_ = data[k]
-                    columns_[c_id_]['target_column'] = target_column_
-                elif k.startswith("category_{}".format(pt_id)):
-                    tc_, c_id_ = k.split('_')[-2:]
-                    tc_value_ = data[k]
-                    if not 'categories' in columns_[c_id_]:
-                        columns_[c_id_]['categories'] = {}
-                    columns_[c_id_]['categories'][tc_] = tc_value_
-                elif k.startswith("column_enabled_{}".format(pt_id)):
-                    c_id_ = k.split('_')[-1]
-                    enabled_ = str(data[k]).lower() == 'true'
-                    columns_[c_id_]['enabled'] = enabled_
+    # selected column values
+    column_values = []
+    for pt in data['selected_pivot_tables']:
+        pt_id = pt['id']
+        pt_type = pt['type']
+        pt_column_values_ = {
+            'id': pt_id,
+        }
+        columns_ = defaultdict(dict)
+        for k in data:
+            if k.startswith("target_column_{}".format(pt_id)):
+                c_id_ = k.split('_')[-1]
+                target_column_ = data[k]
+                columns_[c_id_]['target_column'] = target_column_
+            elif k.startswith("category_{}".format(pt_id)):
+                tc_, c_id_ = k.split('_')[-2:]
+                tc_value_ = data[k]
+                if not 'categories' in columns_[c_id_]:
+                    columns_[c_id_]['categories'] = {}
+                columns_[c_id_]['categories'][tc_] = tc_value_
+            elif k.startswith("column_enabled_{}".format(pt_id)):
+                c_id_ = k.split('_')[-1]
+                enabled_ = str(data[k]).lower() == 'true'
+                columns_[c_id_]['enabled'] = enabled_
 
-            columns_list_ = []
-            for c_id, c_details in columns_.iteritems():
-                c_details['id'] = c_id
-                columns_list_.append(c_details)
+        columns_list_ = []
+        for c_id, c_details in columns_.iteritems():
+            c_details['id'] = c_id
+            columns_list_.append(c_details)
 
-            if edit and not columns_list_:
-                old_column_values = {cv['id']: cv['columns'] for cv in data['column_values']}
-                if pt_id in old_column_values:
-                    pt_column_values_['columns'] = old_column_values[pt_id]
-                else:
-                    pt_column_values_['columns'] = []
+        if edit and not columns_list_:
+            old_column_values = {cv['id']: cv['columns'] for cv in data['column_values']}
+            if pt_id in old_column_values:
+                pt_column_values_['columns'] = old_column_values[pt_id]
             else:
-                pt_column_values_['columns'] = columns_list_
-            column_values.append(pt_column_values_)
-        log.debug("Column values: " + str(column_values))
+                pt_column_values_['columns'] = []
+        else:
+            pt_column_values_['columns'] = columns_list_
+        column_values.append(pt_column_values_)
+    log.debug("Column values: " + str(column_values))
     return data, dhis2_conn_, form_stage
 
 


### PR DESCRIPTION
One thing I'd like @tomeksabala to check:

The pivot table and column config stages of the process are disabled in some circumstances, because without the dhis2 connection up and running they just don't work. 

The conditions for disabling these stages are curently for the pivot table stage:
`{% if not data.pivot_tables %} disabled {% endif %}`
And for the column config stage:
`{% if not data.column_values or not data.pivot_tables %}`
Does this seem sensible to you?

![image](https://user-images.githubusercontent.com/8988344/85683406-1aa42900-b6c5-11ea-9194-90e7f808b556.png)
