### PR TITLE
ADX-419 - Add a nice message asking the user to log in again

### DIFF
--- a/ckanext/dhis2harvester/templates/source/refresh_dhis2_credentials.html
+++ b/ckanext/dhis2harvester/templates/source/refresh_dhis2_credentials.html
@@ -7,6 +7,11 @@
 <H2>
   {{_('Refresh DHIS2 Harvester')}}
 </H2>
+
+<div class="alert alert-warning">
+  <p>Please confirm your DHIS2 login details</p>
+</div>
+
 {% endblock %}
 
 {% block actions %}

--- a/ckanext/dhis2harvester/templates/source/refresh_dhis2_credentials.html
+++ b/ckanext/dhis2harvester/templates/source/refresh_dhis2_credentials.html
@@ -9,7 +9,7 @@
 </H2>
 
 <div class="alert alert-warning">
-  <p>Please confirm your DHIS2 login details</p>
+  <p>{{_('Please confirm your DHIS2 login details')}}</p>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
# Problem
- Currently when you want to re-harvest your data source and your DHIS2 session has expired, we simply display the login page within a re-harvest window.
- There's no UX to the user explaining that they need to log in again, so it's confusing. It's un expected user flow

![image](https://user-images.githubusercontent.com/2634482/96440796-5d53b900-1200-11eb-9ad2-c991e846b452.png)


# Solution
- Display a simple message informing them to log in again
- I'm avoiding saying why they need to log in again, as there could be many reasons.
- Instead i'm just giving them a heads up that they need to auth once again, which is enough to avoid confusion.

![image](https://user-images.githubusercontent.com/2634482/96440899-7f4d3b80-1200-11eb-937e-eeb2b1e34972.png)
