### PR TITLE
ADX-420 - Fixed 'view harvest source' url

### DIFF
--- a/ckanext/dhis2harvester/templates/source/admin_base.html
+++ b/ckanext/dhis2harvester/templates/source/admin_base.html
@@ -32,13 +32,10 @@
         {{ _('Clear') }}
       </a>
 
-
-
-       <a href="{{ h.url_for('{0}_read'.format(c.dataset_type), id=harvest_source.id) }}" class="btn btn-default">
+       <a href="{{ h.url_for('harvest_read', id=harvest_source.name) }}" class="btn btn-default">
         <i class="fa fa-eye eye-open"></i>
         {{ _('View harvest source') }}
       </a>
-
 
 {% endblock %}
 


### PR DESCRIPTION
# Problem
- The `view harvest source` link is wrong and 404s when on the Edit harvester page
- Also, when on the Dashboard view, it wrongly links to the data source's hash ID rather than name

# Solution
- Simply set the url to `harvester/{{harvest_source.name}}` on all views the button is displayed