### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
         pip install ckantoolkit
-        pip install .
+        pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
     - name: Setup extension
@@ -54,4 +54,3 @@ jobs:
         ckan -c test.ini db init
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.dhis2harvester --disable-warnings ckanext/dhis2harvester/tests
-


### PR DESCRIPTION
I'm going around fixing many github actions that do not work due to us  not installing the the extension in editable mode.  It creates an ImportMismatch error in pytest, due to the fact that it can importing e.g. conftest.py from two seperate sources - the local files and the python installation of the module.  