### PR TITLE
ADX-912 Manage multiple api versions

### DIFF
--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -15,29 +15,42 @@ log = logging.getLogger(__name__)
 
 class Dhis2Connection(object):
     DEFAULT_API_VERSION = '26'
-    PIVOT_TABLES_RESOURCE = 'reportTables.json?' \
-                            'fields=id,displayName~rename(name),created,lastUpdated,access,title,description,user&' \
-                            'order=name:asc&paging=false'
-    PIVOT_TABLES_KEY_NAME = "reportTables"
-    PIVOT_TABLES_CSV_RESOURCE = 'analytics.csv?' \
-                                'dimension=dx:{data_elements}&' \
-                                'dimension=pe:{periods}&' \
-                                'dimension=co&' \
-                                'dimension=ou:{organisation_units}&' \
-                                'displayProperty=NAME&' \
-                                'hierarchyMeta=true&' \
-                                'outputIdScheme=UID'
-    PIVOT_TABLE_KEYS = ["lastUpdated", "created", "id", "name"]
-    SECURITY_LOGIN_ACTION = 'dhis-web-commons-security/login.action'
-    ORG_UNIT_RESOURCE = "organisationUnits?paging=false&fields=id,name"
+    API_CONFIG = {
+        26: {
+            "PIVOT_TABLES_RESOURCE": "reportTables.json?" \
+                                     "fields=id,displayName~rename(name),created,lastUpdated,access,title,description,user&" \
+                                     "order=name:asc&paging=false",
+            "PIVOT_TABLES_KEY_NAME": "reportTables",
+            "PIVOT_TABLES_CSV_RESOURCE": 'analytics.csv?' \
+                                         'dimension=dx:{data_elements}&' \
+                                         'dimension=pe:{periods}&' \
+                                         'dimension=co&' \
+                                         'dimension=ou:{organisation_units}&' \
+                                         'displayProperty=NAME&' \
+                                         'hierarchyMeta=true&' \
+                                         'outputIdScheme=UID',
+            "PIVOT_TABLE_KEYS": ["lastUpdated", "created", "id", "name"],
+            "SECURITY_LOGIN_ACTION": 'dhis-web-commons-security/login.action',
+            "ORG_UNIT_RESOURCE": "organisationUnits?paging=false&fields=id,name"
+        },
+        28: {
+            "PIVOT_TABLES_RESOURCE": 'visualizations.json?type=PIVOT_TABLE&' \
+                                     'fields=id,displayName~rename(name),created,lastUpdated,access,title,description,user&' \
+                                     'order=name:asc&paging=false',
+            "PIVOT_TABLES_KEY_NAME": "visualizations"
+        }
+    }
 
-    def __init__(self, url, username=None, password=None, auth_token=None, api_version=DEFAULT_API_VERSION):
+    def __init__(self, url, username=None, password=None, auth_token=None, api_version=None):
+        if not api_version:
+            api_version = self.DEFAULT_API_VERSION
         self.url = self.__add_trailing_slash(url)
         self.api_version = api_version
         self.api_url = self.__api_url(self.url, self.api_version)
         self.username = username
         self.password = password
         self.auth_token = auth_token
+        self.__setup_api_config()
 
     def __str__(self):
         return "Dhis2Connection(api_url={self.api_url}, username={self.username})".format(self=self)
@@ -64,6 +77,14 @@ class Dhis2Connection(object):
             "Authorization": "Basic %s" % u_and_p_b64
         })
         return headers
+
+    def __setup_api_config(self):
+        config = {}
+        for version in sorted(self.API_CONFIG.keys()):
+            if version <= int(self.api_version):
+                config = {**config, **self.API_CONFIG[version]}
+        for key, value in config.items():
+            setattr(self, key, value)
 
     def create_auth_cookie(self):
         if not self.auth_token:


### PR DESCRIPTION
This PR updated the dhis2_api.py to be able to handle different configurations for different api versions. 

Changes in API config that are required by each new version of the DHIS2 API are stored in a separate sub-dictionaries in the API_CONFIG property. These dictionaries are combined in order, up to the specified api version, to assemble the final api config dict, which is then converted into class properties.

Thoughts: 
I am not sure about setting the final config dict values to be class properties, but doing so results in a much smaller and more controlled PR. 
