### PR TITLE
ADX-976 Extracting additional data categories information for data element

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,11 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 2.7, 3.9 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -25,9 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ckan-container-version: "2.9-py2"
-            ckan-postgres-version: "2.9"
-            ckan-solr-version: "2.9-solr8"
           - ckan-container-version: "2.9"
             ckan-postgres-version: "2.9"
             ckan-solr-version: "2.9-solr8"


### PR DESCRIPTION
## Description

DHIS2 data elements usually keep all categories dimensions as `categoryCombo` field:
```
"categoryCombo": {
    "id": "a6WdBu2b63Z"
}
```

This later translates as category options (e.g. males >45).

In Cameroon one of the ART data elements is configured in a different way. In the usual place `categoryCombo` displays only the “default” category which is not useful.

The actual data dimensions are stored in dataSetElements (I’m not really sure why, maybe linking to dataSet data?)
```
 "dataSetElements": [
        {
            "dataElement": {
                "id": "cCxSkWMCAnv"
            },
            "dataSet": {
                "id": "avsYPbqa7q3"
            }
        },
        {
            "categoryCombo": {
                "id": "yc5hfTcD9BG"   <<<< additional category combo
            },
            "dataElement": {
                "id": "cCxSkWMCAnv"
            },
            "dataSet": {
                "id": "uMHYwNtFfLy"
            }
        },
        [...]
```
The easy thing to do is to extract this additional categories from this new place and merge them with ususal `categoryCombo`.
https://fjelltopp.atlassian.net/browse/ADX-976

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
