### PR TITLE
ADX-985 Fixing pivot table pulls for cases where no dhis2 indicators selected

### DIFF
--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -271,12 +271,16 @@ class Dhis2Connection(object):
         }
 
     def get_pivot_table_csv_resource(self, data_elements, ou_levels, periods):
+        if len(data_elements) == 0:
+            return None
         des = ";".join(data_elements)
         ous = ";".join(ou_levels)
         ps = ";".join(periods)
         return self.PIVOT_TABLES_CSV_RESOURCE.format(data_elements=des, periods=ps, organisation_units=ous)
 
     def get_pivot_table_csv_indicators_resource(self, indicators, ou_levels, periods):
+        if len(indicators) == 0:
+            return None
         inds = ";".join(indicators)
         ous = ";".join(ou_levels)
         ps = ";".join(periods)


### PR DESCRIPTION
## Description

After introducing support for DHIS2 indicators it may happen that only dhis2 elements or only dhis2 indicators are selected for the pulls. This situation was not supported by the harvester and was causing issues downstream of the ETL (500 errors from DHIS2 complaining about incorrect API requests).

This fix prevents asking DHIS2 for indicators/data elements if no entries of this type exists for this pivot table configuration.

(This is a high-priority request for the client so I'm going ahead with deploying the change yet I still asking someone for post-merge review, please)

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ x] I have developed these changes in discussion with the appropriate project manager.
- [ x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x ] I have performed a self-review of my own code.
- [x ] I have assigned at least one reviewer.
