### PR TITLE
Adx 1065 new period format support

### DIFF
--- a/ckanext/dhis2harvester/dhis2_periods.py
+++ b/ckanext/dhis2harvester/dhis2_periods.py
@@ -50,8 +50,18 @@ def year_from_dhis2_period_string(dhis2_period_string):
         raise ValueError("Unsupported period string {}".format(dhis2_period_string))
 
 
+def _financial_quarter_to_calendar_quarter(ethiopian_period_string):
+    # reqex to matching ethopian financial quarters (year starting in Nov): 2015NovQ2 2015NovQ3 2015NovQ4
+    financial_quarter_re = r"^[1-2]\d\d\dNovQ[1-4]$"
+    financial_quarter_m = re.search(financial_quarter_re, ethiopian_period_string)
+    if financial_quarter_m:
+        ethiopian_period_string = ethiopian_period_string.replace("Nov", "")
+    return ethiopian_period_string
+
+
 def from_ethiopian_data_to_georgian_date(ethiopian_period_string):
     ethiopian_period_string = _stringify(ethiopian_period_string)
+    ethiopian_period_string = _financial_quarter_to_calendar_quarter(ethiopian_period_string)
     year = int(year_from_dhis2_period_string(ethiopian_period_string))
 
     is_year, is_quarter, is_month = _validate_input(ethiopian_period_string)

--- a/ckanext/dhis2harvester/tests/test_dhis2_periods.py
+++ b/ckanext/dhis2harvester/tests/test_dhis2_periods.py
@@ -141,7 +141,7 @@ def test_period_column_name(pivot_table_type, expected):
     ('201301', '202009'),
     ('201302', '202010'),
     ('201004', '201712'),
-    ('2015NovQ2', '2022Q4'), # Ethiopia uses financial quarters (year starts in month 11.)
+    ('2015NovQ2', '2022Q4'),  # Ethiopia uses financial quarters (year starts in month 11.)
     ('2015NovQ3', '2023Q1'),
     ('2015NovQ4', '2023Q2'),
     ('2016NovQ1', '2023Q3')

--- a/ckanext/dhis2harvester/tests/test_dhis2_periods.py
+++ b/ckanext/dhis2harvester/tests/test_dhis2_periods.py
@@ -141,6 +141,10 @@ def test_period_column_name(pivot_table_type, expected):
     ('201301', '202009'),
     ('201302', '202010'),
     ('201004', '201712'),
+    ('2015NovQ2', '2022Q4'),
+    ('2015NovQ3', '2023Q1'),
+    ('2015NovQ4', '2023Q2'),
+    ('2016NovQ1', '2023Q3')
 ])
 def test_ethiopian(ethiopian_period_string, expected):
     result = dhis2_periods.from_ethiopian_data_to_georgian_date(ethiopian_period_string)

--- a/ckanext/dhis2harvester/tests/test_dhis2_periods.py
+++ b/ckanext/dhis2harvester/tests/test_dhis2_periods.py
@@ -141,7 +141,7 @@ def test_period_column_name(pivot_table_type, expected):
     ('201301', '202009'),
     ('201302', '202010'),
     ('201004', '201712'),
-    ('2015NovQ2', '2022Q4'),
+    ('2015NovQ2', '2022Q4'), # Ethiopia uses financial quarters (year starts in month 11.)
     ('2015NovQ3', '2023Q1'),
     ('2015NovQ4', '2023Q2'),
     ('2016NovQ1', '2023Q3')


### PR DESCRIPTION
## Description

Ethiopia DHIS2 uses financial quarters (year starts in month 11 in Ethopian calendar).
![image](https://github.com/fjelltopp/ckanext-dhis2harvester/assets/30174560/1a7db149-2bde-4ca9-8512-347d85cc38b1)
I have decided to implement a helper function used only for Ethiopian calendar option enabled which identifies if financial quarters are used and translates them to standard quarter period strings used before 2022NovQ1 -> 2022Q1.

## Testing (delete if not applicable)

I have added tests describing the situation.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
