### PR TITLE
ADX-1068 Updated DHIS2 api call for pivot table fetching.

### DIFF
--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -13,9 +13,11 @@ log = logging.getLogger(__name__)
 
 API_CONFIG = {
     37: {
+        # ADR does not support chunking in DHIS2 metadata fetch, some DHIS2 have >8000 pivot tables
+        # as a workaround we fetch pivot tables with names matching UNAIDS or ONUSIDA
         "PIVOT_TABLES_RESOURCE": 'visualizations.json?type=PIVOT_TABLE&'
                                  'fields=id,displayName~rename(name),created,lastUpdated,access,title,description,user&'
-                                 'order=name:asc&paging=false',
+                                 'rootJunction=OR&filter=name:like:UNAIDS&filter=name:like:ONUSIDA&pageSize=200',
         "PIVOT_TABLES_KEY_NAME": "visualizations",
         "PIVOT_TABLES_CSV_RESOURCE": 'analytics.csv?'
                                      'dimension=dx:{data_elements}&'

--- a/ckanext/dhis2harvester/dhis2_periods.py
+++ b/ckanext/dhis2harvester/dhis2_periods.py
@@ -109,7 +109,7 @@ def _validate_input(dhis2_period_string):
 
 def _stringify(dhis2_period_string):
     try:
-        if type(dhis2_period_string) == float:
+        if isinstance(dhis2_period_string, float):
             dhis2_period_string = str(int(dhis2_period_string))
         else:
             dhis2_period_string = str(dhis2_period_string)


### PR DESCRIPTION
## Description

In Cameroon DHIS2 instance is returning 500 error due to the system having >8000 pivot tables.

A workaround would be to minimize the number of pivot tables returned by the query.
I have tried to order the result by lastUpdated date and return last ~200 entries but I couldn’t find a way to order by dates with DHIS2 api.

The only other thing I could came up with was to query pivot tables for either UNAIDS or ONUSIDA (fr). From my experience all countries tag their pivot table with it so I hope the solution will stand.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
