### PR TITLE
feat: upgrade to CKAN 2.10/2.11 + Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,29 @@ jobs:
           flake8 . --count --max-line-length=127 --show-source --statistics
 
   test:
-    name: CKAN 2.11
+    name: CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ckan-version: "2.10"
+            ckan-image: "ckan-dev:2.10-py3.10"
+            postgres-version: "2.10"
+            solr-version: "2.10"
+          - ckan-version: "2.11"
+            ckan-image: "ckan-dev:2.11-py3.10"
+            postgres-version: "2.11"
+            solr-version: "2.11-solr9"
+
     container:
-      image: ckan/ckan-dev:2.11-py3.10
+      image: ckan/${{ matrix.ckan-image }}
       options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:2.11-solr9
+        image: ckan/ckan-solr:${{ matrix.solr-version }}
       postgres:
-        image: ckan/ckan-postgres-dev:2.11
+        image: ckan/ckan-postgres-dev:${{ matrix.postgres-version }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,15 +3,11 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.9, "3.10" ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -19,30 +15,16 @@ jobs:
           flake8 . --count --max-line-length=127 --show-source --statistics
 
   test:
-    name: CKAN
+    name: CKAN 2.11
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - ckan-version: "ckan-dev:2.9-py3.9"
-            ckan-postgres-version: "2.9"
-            ckan-solr-version: "2.9-solr8"
-          - ckan-version: "ckan-dev:2.10-py3.10"
-            ckan-postgres-version: "2.10"
-            ckan-solr-version: "2.10"
-          - ckan-version: "ckan-dev:2.11-py3.10"
-            ckan-postgres-version: "2.11"
-            ckan-solr-version: "2.11-solr9"
-
     container:
-      image: ckan/${{ matrix.ckan-version }}
+      image: ckan/ckan-dev:2.11-py3.10
       options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-solr-version }}
+        image: ckan/ckan-solr:2.11-solr9
       postgres:
-        image: ckan/ckan-postgres-dev:${{ matrix.ckan-postgres-version }}
+        image: ckan/ckan-postgres-dev:2.11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -61,13 +43,16 @@ jobs:
     - uses: actions/checkout@v6
     - name: Install requirements
       run: |
+        pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install ckantoolkit
+        pip install -e git+https://github.com/fjelltopp/ckanext-harvest.git@toavina/update-python#egg=ckanext-harvest
+        pip install -r /srv/app/src/ckanext-harvest/requirements.txt
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
     - name: Setup extension
       run: |
         ckan -c test.ini db init
+        ckan -c test.ini harvester initdb
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.dhis2harvester --disable-warnings ckanext/dhis2harvester/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,15 @@ on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.9, "3.10" ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -21,15 +25,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ckan-container-version: "2.9"
+          - ckan-version: "ckan-dev:2.9-py3.9"
             ckan-postgres-version: "2.9"
             ckan-solr-version: "2.9-solr8"
-          - ckan-container-version: "2.10"
+          - ckan-version: "ckan-dev:2.10-py3.10"
             ckan-postgres-version: "2.10"
             ckan-solr-version: "2.10"
+          - ckan-version: "ckan-dev:2.11-py3.10"
+            ckan-postgres-version: "2.11"
+            ckan-solr-version: "2.11-solr9"
 
     container:
-      image: openknowledge/ckan-dev:${{ matrix.ckan-container-version }}
+      image: ckan/${{ matrix.ckan-version }}
+      options: --user root
     services:
       solr:
         image: ckan/ckan-solr:${{ matrix.ckan-solr-version }}
@@ -50,10 +58,9 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Install requirements
       run: |
-        pip install -r requirements.txt
         pip install -r dev-requirements.txt
         pip install ckantoolkit
         pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install -e git+https://github.com/fjelltopp/ckanext-harvest.git@toavina/update-python#egg=ckanext-harvest
+        pip install -e git+https://github.com/fjelltopp/ckanext-harvest.git@1c1ebb335379eff02db417352db37e1e28e2aa87#egg=ckanext-harvest
         pip install -r /srv/app/src/ckanext-harvest/requirements.txt
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container

--- a/ckanext/dhis2harvester/assets/dhis2_harvester_source_form.css
+++ b/ckanext/dhis2harvester/assets/dhis2_harvester_source_form.css
@@ -1,3 +1,8 @@
+/* Bootstrap 5 compatibility - .hidden class was removed in BS5 */
+.hidden {
+  display: none !important;
+}
+
 /* Fixing bug with jsoneditor not wrapping h3 title with <label> for
     type:array, format:table
 */

--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -169,6 +169,12 @@ class Dhis2Connection(object):
     def get_pivot_tables(self):
         url_ = urljoin(self.api_url, self.PIVOT_TABLES_RESOURCE)
         r = requests.get(url_, cookies=self.create_auth_cookie())
+        # If 404, try newer API config (reportTables removed in DHIS2 >= 2.37)
+        if r.status_code == 404 and self.PIVOT_TABLES_KEY_NAME == "reportTables":
+            log.info("reportTables endpoint not found, trying visualizations endpoint")
+            self.__setup_api_config(37)
+            url_ = urljoin(self.api_url, self.PIVOT_TABLES_RESOURCE)
+            r = requests.get(url_, cookies=self.create_auth_cookie())
         self.response_validation("Failed to get pivot tables information", r)
         try:
             pivot_tables = r.json().get(self.PIVOT_TABLES_KEY_NAME)
@@ -182,6 +188,12 @@ class Dhis2Connection(object):
     def _get_pivot_table_meta(self, pivot_table_id):
         url_ = urljoin(self.api_url, "{}/{}".format(self.PIVOT_TABLES_KEY_NAME, pivot_table_id))
         r = requests.get(url_, cookies=self.create_auth_cookie())
+        # If 404, try newer API config (reportTables removed in DHIS2 >= 2.37)
+        if r.status_code == 404 and self.PIVOT_TABLES_KEY_NAME == "reportTables":
+            log.info("reportTables endpoint not found for pivot table %s, trying visualizations endpoint", pivot_table_id)
+            self.__setup_api_config(37)
+            url_ = urljoin(self.api_url, "{}/{}".format(self.PIVOT_TABLES_KEY_NAME, pivot_table_id))
+            r = requests.get(url_, cookies=self.create_auth_cookie())
         self.response_validation("Failed to get pivot table information for pivot table {}".format(pivot_table_id), r)
         try:
             pivot_table_meta = r.json()

--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -2,8 +2,7 @@ import json
 import logging
 from base64 import b64encode
 
-import six
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 import requests
 from requests.exceptions import MissingSchema, RequestException
 
@@ -96,7 +95,7 @@ class Dhis2Connection(object):
     def __create_dhis2_headers(self, headers=None):
         if headers is None:
             headers = {}
-        u_and_p = b"%s:%s" % (self.username, self.password)
+        u_and_p = "{}:{}".format(self.username, self.password).encode()
         u_and_p_b64 = b64encode(u_and_p).decode("ascii")
         headers.update({
             "Content-Type": "application/json",
@@ -145,8 +144,8 @@ class Dhis2Connection(object):
             log.debug(msg_)
             raise (Dhis2ConnectionError(msg_))
         except MissingSchema as ms:
-            log.debug(ms.message)
-            raise (Dhis2ConnectionError(ms.message))
+            log.debug(str(ms))
+            raise (Dhis2ConnectionError(str(ms)))
 
     def get_details(self):
         return self.url, self.api_version, self.get_auth_token()
@@ -182,7 +181,7 @@ class Dhis2Connection(object):
             raise Dhis2ConnectionError("Failed to decode response for pivot table")
         result = []
         for table in pivot_tables:
-            result.append({k: v for k, v in six.iteritems(table) if k in self.PIVOT_TABLE_KEYS})
+            result.append({k: v for k, v in table.items() if k in self.PIVOT_TABLE_KEYS})
         return result
 
     def _get_pivot_table_meta(self, pivot_table_id):
@@ -240,7 +239,7 @@ class Dhis2Connection(object):
                 category_options_ = dict()
                 for cc_id in cc_ids_:
                     category_options_.update(category_combos_map[cc_id])
-                for co_id, co_name in six.iteritems(category_options_):
+                for co_id, co_name in category_options_.items():
                     data_element_category_options_.append({
                         "id": "-".join([d_id_, co_id]),
                         "name": " / ".join([d_name_, co_name])

--- a/ckanext/dhis2harvester/harvesters/pivot_tables_harvester.py
+++ b/ckanext/dhis2harvester/harvesters/pivot_tables_harvester.py
@@ -98,9 +98,10 @@ class PivotTablesHarvester(HarvesterBase):
             pt_target_type = PT_TARGET_TYPES[pt_type]
             try:
                 pt_config = dhis2_connection.get_pivot_table_configuration(pt_id)
-            except dhis2_api.Dhis2ConnectionError as e:
+            except dhis2_api.Dhis2ConnectionError:
+                log.exception("Failed to get pivot table configuration for %s", pt_id)
                 self._save_gather_error(
-                    'Failed to get pivot table configuration for {}: {}'.format(pt_id, e),
+                    'Failed to get pivot table configuration for {}'.format(pt_id),
                     harvest_job)
                 continue
             data_elements = [c['id'].split('-')[0] for c in pt['columns'] if '-' in c['id']]
@@ -191,9 +192,10 @@ class PivotTablesHarvester(HarvesterBase):
         dhis2_connection = self._get_dhis2_connection(content)
         try:
             dhis2_connection.test_connection()
-        except dhis2_api.Dhis2ConnectionError as e:
+        except dhis2_api.Dhis2ConnectionError:
+            log.exception("Unable to get connection to dhis2: %s", dhis2_connection)
             self._save_object_error(
-                'Unable to get connection to dhis2: {}: {}'.format(dhis2_connection, e),
+                'Unable to get connection to dhis2: {}'.format(dhis2_connection),
                 harvest_object, 'Fetch')
             return None
         dhis2_api_full_resource = content.get('dhis2_api_full_resource')
@@ -206,15 +208,16 @@ class PivotTablesHarvester(HarvesterBase):
                 pt_df = pd.read_csv(csv_stream, sep=",", encoding='utf-8')
             else:
                 pt_df = pd.DataFrame()
-        except dhis2_api.Dhis2ConnectionError as e:
-            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+        except dhis2_api.Dhis2ConnectionError:
+            log.exception("Unable to get dhis2 data elements: %s: %s", dhis2_api_full_resource, dhis2_connection)
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection),
                                     harvest_object, 'Fetch')
             return None
-        except Exception as e:
+        except Exception:
             log.exception("Failed to parse data element resources for pivot table.")
-            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection),
                                     harvest_object, 'Fetch')
             return None
 
@@ -225,15 +228,16 @@ class PivotTablesHarvester(HarvesterBase):
                 pt_indicator_df = pd.read_csv(csv_indicator_stream, sep=",", encoding='utf-8')
             else:
                 pt_indicator_df = pd.DataFrame()
-        except dhis2_api.Dhis2ConnectionError as e:
-            self._save_object_error('Unable to get dhis2 data: {}: {}: {}'
-                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+        except dhis2_api.Dhis2ConnectionError:
+            log.exception("Unable to get dhis2 data: %s: %s", dhis2_api_full_resource, dhis2_connection)
+            self._save_object_error('Unable to get dhis2 data: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection),
                                     harvest_object, 'Fetch')
             return None
-        except Exception as e:
+        except Exception:
             log.exception("Failed to parse indicator resources for pivot table.")
-            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection),
                                     harvest_object, 'Fetch')
             return None
         try:
@@ -244,8 +248,9 @@ class PivotTablesHarvester(HarvesterBase):
             pt_df = pd.concat([pt_df, pt_indicator_df])
             try:
                 ou_id_name_map = dhis2_connection.get_organisation_unit_name_id_map()
-            except dhis2_api.Dhis2ConnectionError as e:
-                self._save_object_error('Unable to get dhis2 org unit data: {}: {}'.format(dhis2_connection, e),
+            except dhis2_api.Dhis2ConnectionError:
+                log.exception("Unable to get dhis2 org unit data: %s", dhis2_connection)
+                self._save_object_error('Unable to get dhis2 org unit data: {}'.format(dhis2_connection),
                                         harvest_object, 'Fetch')
                 return None
             _org_unit_col = 'Organisation unit'

--- a/ckanext/dhis2harvester/harvesters/pivot_tables_harvester.py
+++ b/ckanext/dhis2harvester/harvesters/pivot_tables_harvester.py
@@ -1,6 +1,6 @@
 import logging
 import requests
-import six
+from io import StringIO, BytesIO
 from ckan.lib import uploader
 
 from ckanext.harvest.harvesters import HarvesterBase
@@ -20,8 +20,6 @@ import uuid
 import json
 
 import sys
-
-from six import StringIO
 log = logging.getLogger(__name__)
 
 
@@ -91,14 +89,20 @@ class PivotTablesHarvester(HarvesterBase):
             return None
         area_id_map_url = config['area_id_map_url']
         area_id_map_owner = config['area_id_map_owner']
-        title_ = six.text_type(harvest_job.source.title)
+        title_ = str(harvest_job.source.title)
         output_dataset_name_prefix = '{} Output'.format(title_)
         period_conversion_type = config.get('period_conversion_type')
         for pt in config['column_values']:
             pt_id = pt['id']
             pt_type = {x['id']: x for x in config['selected_pivot_tables']}[pt_id]['type']
             pt_target_type = PT_TARGET_TYPES[pt_type]
-            pt_config = dhis2_connection.get_pivot_table_configuration(pt_id)
+            try:
+                pt_config = dhis2_connection.get_pivot_table_configuration(pt_id)
+            except dhis2_api.Dhis2ConnectionError as e:
+                self._save_gather_error(
+                    'Failed to get pivot table configuration for {}: {}'.format(pt_id, e),
+                    harvest_job)
+                continue
             data_elements = [c['id'].split('-')[0] for c in pt['columns'] if '-' in c['id']]
             indicators = [c['id'] for c in pt['columns'] if '-' not in c['id']]
             csv_resource_name = dhis2_connection.get_pivot_table_csv_resource(
@@ -188,8 +192,8 @@ class PivotTablesHarvester(HarvesterBase):
         try:
             dhis2_connection.test_connection()
         except dhis2_api.Dhis2ConnectionError as e:
-            self._save_object_error_error(
-                'Unable to get connection to dhis2: {}: {}'.format(dhis2_connection, e.message),
+            self._save_object_error(
+                'Unable to get connection to dhis2: {}: {}'.format(dhis2_connection, e),
                 harvest_object, 'Fetch')
             return None
         dhis2_api_full_resource = content.get('dhis2_api_full_resource')
@@ -203,15 +207,15 @@ class PivotTablesHarvester(HarvesterBase):
             else:
                 pt_df = pd.DataFrame()
         except dhis2_api.Dhis2ConnectionError as e:
-            self._save_object_error_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                          .format(dhis2_api_full_resource, dhis2_connection, e.message),
-                                          harvest_object, 'Fetch')
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+                                    harvest_object, 'Fetch')
             return None
         except Exception as e:
             log.exception("Failed to parse data element resources for pivot table.")
-            self._save_object_error_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                          .format(dhis2_api_full_resource, dhis2_connection, e.message),
-                                          harvest_object, 'Fetch')
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+                                    harvest_object, 'Fetch')
             return None
 
         try:
@@ -222,15 +226,15 @@ class PivotTablesHarvester(HarvesterBase):
             else:
                 pt_indicator_df = pd.DataFrame()
         except dhis2_api.Dhis2ConnectionError as e:
-            self._save_object_error_error('Unable to get dhis2 data: {}: {}: {}'
-                                          .format(dhis2_api_full_resource, dhis2_connection, e.message),
-                                          harvest_object, 'Fetch')
+            self._save_object_error('Unable to get dhis2 data: {}: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+                                    harvest_object, 'Fetch')
             return None
         except Exception as e:
             log.exception("Failed to parse indicator resources for pivot table.")
-            self._save_object_error_error('Unable to get dhis2 data elements: {}: {}: {}'
-                                          .format(dhis2_api_full_resource, dhis2_connection, e.message),
-                                          harvest_object, 'Fetch')
+            self._save_object_error('Unable to get dhis2 data elements: {}: {}: {}'
+                                    .format(dhis2_api_full_resource, dhis2_connection, e),
+                                    harvest_object, 'Fetch')
             return None
         try:
             _category_column = 'Category option combo'
@@ -241,7 +245,7 @@ class PivotTablesHarvester(HarvesterBase):
             try:
                 ou_id_name_map = dhis2_connection.get_organisation_unit_name_id_map()
             except dhis2_api.Dhis2ConnectionError as e:
-                self._save_object_error('Unable to get dhis2 org unit data: {}: {}'.format(dhis2_connection, e.message),
+                self._save_object_error('Unable to get dhis2 org unit data: {}: {}'.format(dhis2_connection, e),
                                         harvest_object, 'Fetch')
                 return None
             _org_unit_col = 'Organisation unit'
@@ -303,7 +307,7 @@ class PivotTablesHarvester(HarvesterBase):
                 for tc in c['target_column']:
                     _data_cols.add(tc)
                     pt_df.loc[i, tc] = _factor * row['Value']
-                for cat, cat_val in six.iteritems(c['categories']):
+                for cat, cat_val in c['categories'].items():
                     _cat_cols.add(cat)
                     pt_df.loc[i, cat] = cat_val
             pt_df = pt_df.drop(_index_to_drop)
@@ -410,7 +414,7 @@ class PivotTablesHarvester(HarvesterBase):
 
         package_data = {
             "name": slugify(dataset_name),
-            "title": six.text_type(dataset_name),
+            "title": str(dataset_name),
             "type": "dataset-2",
             "tags": [{"name": tag} for tag in content.get('output_tags', [])],
             "state": "active",
@@ -434,7 +438,7 @@ class PivotTablesHarvester(HarvesterBase):
             package_data["id"] = str(uuid.uuid4())
             new_package = t.get_action('package_create')(context, package_data)
 
-        csv_stream = six.BytesIO(six.text_type(csv_string).encode(encoding='UTF-8'))
+        csv_stream = BytesIO(csv_string.encode(encoding='UTF-8'))
         csv_filename = "{}.csv".format(slugify(resource_name.replace('/', '').replace(':', '-')))
         resource = {
             "name": resource_name,

--- a/ckanext/dhis2harvester/template_helpers.py
+++ b/ckanext/dhis2harvester/template_helpers.py
@@ -1,10 +1,8 @@
-import six
-
 from ckan.plugins import toolkit
 
 
 def iteritems(dictionary):
-    return six.iteritems(dictionary)
+    return dictionary.items()
 
 
 def organization_select_options(action):

--- a/ckanext/dhis2harvester/templates/snippets/harvest_run_action.html
+++ b/ckanext/dhis2harvester/templates/snippets/harvest_run_action.html
@@ -1,13 +1,13 @@
 {% if harvest_source.status and harvest_source.status.last_job and (harvest_source.status.last_job.status == 'New' or harvest_source.status.last_job.status == 'Running') %}
-  <a class="btn btn-default disabled" rel="tooltip" title="There already is an unrun job for this source"><i class="fa fa-lg fa-refresh icon-refresh icon-large"></i> {{  _('Running...') }}</a>
+  <a class="btn btn-secondary disabled" rel="tooltip" title="There already is an unrun job for this source"><i class="fa fa-lg fa-refresh icon-refresh icon-large"></i> {{  _('Running...') }}</a>
 {% else %}
   {% set locale = h.dump_json({'content': _('This will re-run the DHIS2 import for this source. Any updates at the source will overwrite the local datasets. Sources with a large number of datasets may take a significant amount of time to finish refreshing. Please confirm you would like us to start refreshing.')}) %}
   {% if harvest_source.source_type == 'dhis2-pivot-tables' %}
     {% set harvest_refresh_url = h.url_for('dhis2_harvester.pivot_tables_refresh', harvest_source_id=harvest_source.name) %}
   {% else %}
-    {% set harvest_refresh_url = h.url_for('harvest_refresh', id=harvest_source.name) %}
+    {% set harvest_refresh_url = h.url_for('harvester.refresh', id=harvest_source.name) %}
   {% endif %}
-  <a href="{{ harvest_refresh_url }}" class="btn btn-default" data-module="confirm-action" data-module-i18n="{{ locale }}"
+  <a href="{{ harvest_refresh_url }}" class="btn btn-secondary" data-module="confirm-action" data-module-i18n="{{ locale }}"
      title="{{ _('Start a new import job for this DHIS2 source now') }}">
     <i class="fa fa-refresh icon-refresh"></i>
     {{ _('Refresh') }}

--- a/ckanext/dhis2harvester/templates/source/admin_base.html
+++ b/ckanext/dhis2harvester/templates/source/admin_base.html
@@ -1,8 +1,8 @@
 {% ckan_extends %}
 
 {% block page_header_tabs %}
-  {{ h.build_nav_icon('harvest_admin', _('Dashboard'), id=harvest_source.name, icon='dashboard') }}
-  {{ h.build_nav_icon('harvest_job_list', _('Jobs'), source=harvest_source.name, icon='reorder') }}
+  {{ h.build_nav_icon('harvester.admin', _('Dashboard'), id=harvest_source.name, icon='dashboard') }}
+  {{ h.build_nav_icon('harvester.job_list', _('Jobs'), source=harvest_source.name, icon='reorder') }}
   {% if harvest_source.source_type == 'dhis2-pivot-tables' %}
     <li>
       <a  href="{{ h.url_for('dhis2_harvester.pivot_tables_edit', harvest_source_id=harvest_source.id) }}">
@@ -11,7 +11,7 @@
       </a>
     </li>
   {% else %}
-    {{ h.build_nav_icon('harvest_edit', _('Edit'), id=harvest_source.name, icon='edit') }}
+    {{ h.build_nav_icon('harvest.edit', _('Edit'), id=harvest_source.name, icon='edit') }}
   {% endif %}
 {% endblock %}
 
@@ -19,7 +19,7 @@
   {% snippet 'snippets/harvest_run_action.html', harvest_source=harvest_source %}
   {% if harvest_source.status and harvest_source.status.last_job and (harvest_source.status.last_job.status == 'Running') %}
 
-      <a href="{{ h.url_for('harvest_job_abort', source=harvest_source.name, id=harvest_source.status.last_job.id) }}" class="btn btn-default" title="Stop this Job">
+      <a href="{{ h.url_for('harvester.job_abort', source=harvest_source.name, id=harvest_source.status.last_job.id) }}" class="btn btn-secondary" title="Stop this Job">
         <i class="fa fa-ban icon-ban-circle"></i>
         {{ _('Stop') }}
       </a>
@@ -27,12 +27,12 @@
   {% endif %}
     {% set locale = h.dump_json({'content': _('Warning: This will remove all datasets for this source, as well as all previous job reports. Are you sure you want to continue?')}) %}
 
-      <a href="{{ h.url_for('harvest_clear', id=harvest_source.id) }}" class="btn btn-default" data-module="confirm-action" data-module-i18n="{{ locale }}"
+      <a href="{{ h.url_for('harvester.clear', id=harvest_source.id) }}" class="btn btn-secondary" data-module="confirm-action" data-module-i18n="{{ locale }}"
          title="{{ _('Delete all import jobs and existing datasets from this DHIS2 source') }}">
         {{ _('Clear') }}
       </a>
 
-       <a href="{{ h.url_for('harvest_read', id=harvest_source.name) }}" class="btn btn-default">
+       <a href="{{ h.url_for('harvest.read', id=harvest_source.name) }}" class="btn btn-secondary">
         <i class="fa fa-eye eye-open"></i>
         {{ _('View DHIS2 source') }}
       </a>

--- a/ckanext/dhis2harvester/templates/source/base.html
+++ b/ckanext/dhis2harvester/templates/source/base.html
@@ -5,10 +5,10 @@
     {% set org = harvest_source.organization %}
     <li>{{ h.nav_link(_('Organizations'), named_route='organizations_index') }}</li>
     <li>{{ h.nav_link(org.title or org.name|truncate(10), named_route='organization_read', id=org.name) }}</li>
-    <li>{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest_search', organization=org.name) }}</li>
-    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(harvest_source.title|truncate(10), named_route='harvest_read', id=harvest_source.name) }}</li>
+    <li>{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest.search', organization=org.name) }}</li>
+    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(harvest_source.title|truncate(10), named_route='harvest.read', id=harvest_source.name) }}</li>
   {% else %}
-    <li>{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest_search') }}</li>
-    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(harvest_source.title|truncate(30), named_route='harvest_read', id=harvest_source.name) }}</li>
+    <li>{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest.search') }}</li>
+    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(harvest_source.title|truncate(30), named_route='harvest.read', id=harvest_source.name) }}</li>
   {% endif %}
 {% endblock %}

--- a/ckanext/dhis2harvester/templates/source/dhis2_credentials.html
+++ b/ckanext/dhis2harvester/templates/source/dhis2_credentials.html
@@ -59,7 +59,7 @@
 {% endblock %}
 {% block actions %}
 <div class="form-nav">
-    <button class="btn btn-default" type="submit" name="action" value="pivot_table_new_1">{{_("Next")}}</button>
+    <button class="btn btn-secondary" type="submit" name="action" value="pivot_table_new_1">{{_("Next")}}</button>
 </div>
 {% endblock %}
 </div>

--- a/ckanext/dhis2harvester/templates/source/pivot_table_base.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_base.html
@@ -15,13 +15,13 @@
     {% set org = g.owner_org %}
     <li>{{ h.nav_link(_('Organizations'), controller='organization', action='index') }}</li>
     <li>{{ h.nav_link(org.title or org.name|truncate(10), controller='organization', action='read', id=org.name) }}</li>
-    <li><a href="{{ h.url_for('harvest_search', organization=org.name)}}">{{_('DHIS2 Sources')}}</a></li>
-    <li><a  href="{{ h.url_for('harvest_read', id=harvest_source.name) }}">{{ harvest_source.title|truncate(15) }}</a></li>
+    <li><a href="{{ h.url_for('harvest.search', organization=org.name)}}">{{_('DHIS2 Sources')}}</a></li>
+    <li><a  href="{{ h.url_for('harvest.read', id=harvest_source.name) }}">{{ harvest_source.title|truncate(15) }}</a></li>
     <li{{ self.breadcrumb_content_root_selected() }}>
-      <a  href="{{ h.url_for('harvest_admin', id=harvest_source.name) }}">Admin</a>
+      <a  href="{{ h.url_for('harvester.admin', id=harvest_source.name) }}">Admin</a>
     </li>
   {% else %}
-    <li><a href="{{  h.url_for('harvest_search')}}">{{_('DHIS2 Sources')}}</a></li>
+    <li><a href="{{  h.url_for('harvest.search')}}">{{_('DHIS2 Sources')}}</a></li>
     <li class="active">
       <a  href="{{ h.url_for('dhis2_harvester.pivot_tables_new') }}">{{ _('Create DHIS2 Pivot Table Fetcher') }}</a>
     </li>
@@ -30,12 +30,12 @@
 
 {% block page_header_tabs %}
   <li>
-    <a href="{{ h.url_for('harvest_admin', id=harvest_source.name) }}">
+    <a href="{{ h.url_for('harvester.admin', id=harvest_source.name) }}">
       <i class="fa fa-dashboard"></i> {{ _('Dashboard') }}
     </a>
   </li>
   <li>
-    <a href="{{ h.url_for('harvest_job_list', source=harvest_source.name) }}">
+    <a href="{{ h.url_for('harvester.job_list', source=harvest_source.name) }}">
       <i class="fa fa-reorder"></i> {{ _('Jobs') }}
     </a>
   </li>

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new.html
@@ -1,15 +1,26 @@
-{% if not h.organizations_available('create_dataset')
-        and not h.check_config_permission('ckan.auth.create_unowned_dataset') %}
+{% extends "source/pivot_table_base.html" %}
+{% import 'macros/form.html' as form %}
 
-    {% include "package/snippets/cannot_create_package.html" %}
+{% set can_create = h.organizations_available('create_dataset') or h.check_config_permission('ckan.auth.create_unowned_dataset') %}
 
+{% block form_content %}
+{% if not can_create %}
+  <section class="module">
+    <div class="module-content">
+      {% if h.check_access('organization_create') %}
+        <div class="alert alert-warning">{{ _('Before you can create a DHIS2 source you need to create an organization.') }}</div>
+        <a class='btn btn-primary' href="{{ h.url_for('organization.new') }}">
+          {{ _('Create a new organization') }}
+        </a>
+      {% else %}
+        <div class="alert alert-danger">
+          <p>{{ _('There are no organizations to which you can assign this DHIS2 source.') }}</p>
+          <p>{{ _('Ask a system administrator to create an organization before you can continue.') }}</p>
+        </div>
+      {% endif %}
+    </div>
+  </section>
 {% else %}
-  {% extends "source/pivot_table_base.html" %}
-  {% import 'macros/form.html' as form %}
-
-
-  {% block form_content %}
-
   <form id="source-new" class="dhis2-source-new form-horizontal dataset-form {{ h.bootstrap_version() }}" method="post">
 
     {% set stage_2_denied = not data.dhis2_auth_token %}
@@ -17,10 +28,10 @@
     {% set stage_4_denied = not data.dhis2_auth_token or not data.selected_pivot_tables or not data.column_values %}
 
     <div class="formnav-stages row">
-      <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_1' %}btn-primary{% endif %}" type="submit" name="action" value="back.pivot_table_new_1">{{_('DHIS2 Connection')}} <i class="fa fa-angle-right"></i></button>
-      <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_2' %}btn-primary{% endif %}" {% if stage_2_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_2">{{_('Pivot Tables')}} <i class="fa fa-angle-right"></i></button>
-      <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_3' %}btn-primary{% endif %}" {% if stage_3_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_3">{{_('Column Configuration')}} <i class="fa fa-angle-right"></i></button>
-      <button class="col-xs-12 col-md-6 col-lg-3 btn btn-default formnav-stage-link {% if data.action == 'pivot_table_new_4' %}btn-primary{% endif %}" {% if stage_4_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_4">{{_('DHIS2 Source Details')}}</button>
+      <button class="col-12 col-md-6 col-lg-3 btn formnav-stage-link {% if data.action == 'pivot_table_new_1' %}btn-primary{% else %}btn-light{% endif %}" type="submit" name="action" value="back.pivot_table_new_1">{{_('DHIS2 Connection')}} <i class="fa fa-angle-right"></i></button>
+      <button class="col-12 col-md-6 col-lg-3 btn formnav-stage-link {% if data.action == 'pivot_table_new_2' %}btn-primary{% else %}btn-light{% endif %}" {% if stage_2_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_2">{{_('Pivot Tables')}} <i class="fa fa-angle-right"></i></button>
+      <button class="col-12 col-md-6 col-lg-3 btn formnav-stage-link {% if data.action == 'pivot_table_new_3' %}btn-primary{% else %}btn-light{% endif %}" {% if stage_3_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_3">{{_('Column Configuration')}} <i class="fa fa-angle-right"></i></button>
+      <button class="col-12 col-md-6 col-lg-3 btn formnav-stage-link {% if data.action == 'pivot_table_new_4' %}btn-primary{% else %}btn-light{% endif %}" {% if stage_4_denied %} disabled {% endif %} type="submit" name="action" value="back.pivot_table_new_4">{{_('DHIS2 Source Details')}}</button>
     </div>
 
     {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
@@ -53,18 +64,17 @@
           {% set locale_delete = h.dump_json({'content': _('This will flag the source as deleted but keep all its datasets and previous jobs. Are you sure you want to delete this harvest source?')}) %}
           {% set locale_clear = h.dump_json({'content': _('Warning: Apart from deleting this source, this command will remove all its datasets, as well as all previous job reports. Are you sure you want to continue?')}) %}
           <div class="dropdown btn-group">
-            <a href="#" class="btn btn-danger dropdown-toggle" data-toggle="dropdown">
+            <a href="#" class="btn btn-danger dropdown-toggle" data-bs-toggle="dropdown">
               {{ _('Delete') }}
-              <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
               <li>
-                <a href="{% url_for 'harvest_delete', id=harvest_source.name %}" data-module="confirm-action" data-module-i18n="{{ locale_delete }}">
+                <a class="dropdown-item" href="{% url_for 'harvest.delete', id=harvest_source.name %}" data-module="confirm-action" data-module-i18n="{{ locale_delete }}">
                   {{ _('Delete source') }}
                 </a>
               </li>
               <li>
-                <a href="{% url_for 'harvest_delete', id=harvest_source.name %}?clear=True" data-module="confirm-action" data-module-i18n="{{ locale_clear }}">
+                <a class="dropdown-item" href="{% url_for 'harvest.delete', id=harvest_source.name %}?clear=True" data-module="confirm-action" data-module-i18n="{{ locale_clear }}">
                   {{ _('Delete and clear source') }}
                 </a>
               </li>
@@ -80,5 +90,5 @@
       <div class="throbber-message">{{_('Talking to DHIS2')}}</div>
     </div>
   </div>
-  {% endblock %}
-{% endif  %}
+{% endif %}
+{% endblock %}

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new_2.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new_2.html
@@ -12,7 +12,7 @@
         options=data.pivot_tables,
         selected=pivot_table.id,
         error=errors.pivot_table_id,
-        classes=['pivot-table-selector', 'control-medium', 'no-label', 'col-xs-12', 'col-md-7'],
+        classes=['pivot-table-selector', 'control-medium', 'no-label', 'col-12', 'col-md-7'],
         attrs={
           "data-module": "autocomplete"
         }
@@ -24,11 +24,11 @@
         options=data.target_types,
         selected=pivot_table.type,
         error=errors.pivot_table_id,
-        classes=['control-medium', 'no-label', 'col-xs-10', 'col-md-4']
+        classes=['control-medium', 'no-label', 'col-10', 'col-md-4']
         )
     }}
 
-    <div class="delete-btn form-group control-medium col-xs-2 col-md-1">
+    <div class="delete-btn form-group control-medium col-2 col-md-1">
       <button class="btn btn-primary" disabled
               data-module='pivot_table_delete'
               data-module-source=".pivot-table-new-2 .row.pivot-table"
@@ -45,7 +45,7 @@
         id='pivot_table_id',
         options=data.pivot_tables,
         error=errors.pivot_table_id,
-        classes=['pivot-table-selector', 'control-medium', 'no-label', 'col-xs-12', 'col-md-7'],
+        classes=['pivot-table-selector', 'control-medium', 'no-label', 'col-12', 'col-md-7'],
         attrs={
           "data-module": "autocomplete"
         }
@@ -56,11 +56,11 @@
         id='pivot_table_target_type',
         options=data.target_types,
         error=errors.pivot_table_id,
-        classes=['control-medium', 'no-label', 'col-xs-10', 'col-md-4']
+        classes=['control-medium', 'no-label', 'col-10', 'col-md-4']
         )
               }}
 
-      <div class="delete-btn form-group control-medium col-xs-2 col-md-1">
+      <div class="delete-btn form-group control-medium col-2 col-md-1">
         <button class="btn btn-primary" disabled
                 data-module='pivot_table_delete'
                 data-module-source=".pivot-table-new-2 .row.pivot-table"
@@ -73,7 +73,7 @@
 </div>
 
 <div  class="row">
-  <div class="add-btn form-group control-medium col-xs-2 col-md-1">
+  <div class="add-btn form-group control-medium col-2 col-md-1">
     <button class="btn btn-success"
             data-module="pivot_table_add"
             data-module-source=".pivot-table-new-2 .row.pivot-table"
@@ -86,7 +86,7 @@
 </div>
 
 <div class="form-nav">
-  <button class="btn btn-default" type="submit" name="action" value="back.pivot_table_new_1">{{_("Previous")}}</button>
-  <button class="btn btn-default" type="submit" name="action" value="pivot_table_new_2">{{_("Next")}}</button>
+  <button class="btn btn-secondary" type="submit" name="action" value="back.pivot_table_new_1">{{_("Previous")}}</button>
+  <button class="btn btn-secondary" type="submit" name="action" value="pivot_table_new_2">{{_("Next")}}</button>
 </div>
 </div>

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new_3.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new_3.html
@@ -22,18 +22,18 @@
   <div class="pivot-table-config {% if loop.index > 1 %}hidden{% endif %}" tab_page="{{pivot_table.id}}">
     <div class="header">
       <div class="element row">
-        <span class="label col-xs-12 col-sm-3">{{ _('Source DHIS2 pivot table') }}:</span>
-        <div class="col-xs-12 col-sm-9">
+        <span class="label col-12 col-sm-3">{{ _('Source DHIS2 pivot table') }}:</span>
+        <div class="col-12 col-sm-9">
           <span class="value">{{pivot_table.text}}</span><br />
           <span class="small">({{_('DHIS2 ID:')}} {{pivot_table.id}})</span>
         </div>
       </div>
       <div class="element row">
-        <span class="label col-xs-12 col-sm-3">{{ _('ADR Mapping Type') }}:</span>
-        <span class="value col-xs-12 col-sm-9">{{target_type_name}}</span>
+        <span class="label col-12 col-sm-3">{{ _('ADR Mapping Type') }}:</span>
+        <span class="value col-12 col-sm-9">{{target_type_name}}</span>
       </div>
       <div class="element row">
-        <span class="col-xs-12">
+        <span class="col-12">
           {{  _('The pivot table <strong>{pivot_table_name}</strong>, with ID: <strong>{pivot_table_id}</strong>
           in your DHIS2 system will be used to populate the <strong>{table_type_name}</strong> ADR table.')
           .format(
@@ -76,7 +76,7 @@
                     options=column_options,
                     selected=column_data.target_column if column_data else column_options[0],
                     error=errors.pivot_table_id,
-                    classes=['control-medium', 'col-xs-12', 'col-md-4']
+                    classes=['control-medium', 'col-12', 'col-md-4']
                     )
                       }}
 
@@ -92,14 +92,14 @@
                       options=category_options,
                       selected=column_data.categories[category] if column_data else category_options[0].value,
                       error=errors.pivot_table_id,
-                      classes=['control-medium', 'col-xs-12', 'col-md-4']
+                      classes=['control-medium', 'col-12', 'col-md-4']
                       )
                         }}
                   {% endfor %}
                 {% endif %}
               </div>
               <div class="row">
-                <div class="col-xs-12">
+                <div class="col-12">
                   {{ form.checkbox(
                         'negative;{};{}'.format(pivot_table.id, column.value),
                         label=_('Negative value'),
@@ -143,7 +143,7 @@
                     options=column_options,
                     selected=column_data.target_column if column_data else column_options[0],
                     error=errors.pivot_table_id,
-                    classes=['control-medium', 'col-xs-12', 'col-md-4']
+                    classes=['control-medium', 'col-12', 'col-md-4']
                     )
                 }}
 
@@ -159,14 +159,14 @@
                       options=category_options,
                       selected=column_data.categories[category] if column_data else category_options[0].value,
                       error=errors.pivot_table_id,
-                      classes=['control-medium', 'col-xs-12', 'col-md-4']
+                      classes=['control-medium', 'col-12', 'col-md-4']
                       )
                   }}
                 {% endfor %}
               {% endif %}
             </div>
             <div class="row">
-              <div class="col-xs-12">
+              <div class="col-12">
                 {{ form.checkbox(
                         'negative;{};{}'.format(pivot_table.id, column.value),
                         label=_('Negative value'),
@@ -184,7 +184,7 @@
 {% endfor %}
 
   <div class="form-nav">
-    <button class="btn btn-default" type="submit" name="action" value="back.pivot_table_new_2">{{_("Previous")}}</button>
-    <button class="btn btn-default" type="submit" name="action" value="pivot_table_new_3">{{_("Next")}}</button>
+    <button class="btn btn-secondary" type="submit" name="action" value="back.pivot_table_new_2">{{_("Previous")}}</button>
+    <button class="btn btn-secondary" type="submit" name="action" value="pivot_table_new_3">{{_("Next")}}</button>
   </div>
 </div>

--- a/ckanext/dhis2harvester/templates/source/pivot_table_new_4.html
+++ b/ckanext/dhis2harvester/templates/source/pivot_table_new_4.html
@@ -4,7 +4,7 @@
 {{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full'], attrs={'data-module': 'slug-preview-target', 'class': 'form-control'}) }}
 
 {% set prefix = 'harvest' %}
-{% set domain = h.url_for('harvest_read', id='', qualified=true) %}
+{% set domain = h.url_for('harvest.read', id='', qualified=true) %}
 {% set domain = domain|replace("http://", "")|replace("https://", "") %}
 {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<harvest-source>'} %}
 
@@ -61,6 +61,6 @@
 
 <input type="hidden" name="source_type" value="dhis2_pivot_table" >
 <div class="form-nav">
-  <button class="btn btn-default" type="submit" name="action" value="back.pivot_table_new_3">{{_("Previous")}}</button>
+  <button class="btn btn-secondary" type="submit" name="action" value="back.pivot_table_new_3">{{_("Previous")}}</button>
 </div>
 </div>

--- a/ckanext/dhis2harvester/templates/source/search.html
+++ b/ckanext/dhis2harvester/templates/source/search.html
@@ -1,7 +1,7 @@
 {% ckan_extends %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest_search') }}</li>
+  <li class="active">{{ h.nav_link(_('DHIS2 Sources'), named_route='harvest.search') }}</li>
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/dhis2harvester/ui_blueprint.py
+++ b/ckanext/dhis2harvester/ui_blueprint.py
@@ -1,6 +1,5 @@
 import json
-import six
-from six import StringIO
+from io import StringIO
 import logging
 import requests
 import pandas as pd
@@ -271,7 +270,7 @@ def __save_or_update_harvest_source(data, harvest_source=None):
             else:
                 data['area_id_map_owner'] = current_user.name
         except Exception as e:
-            errors = {"area_id_map_url": [_("Failed to download the area id map csv file."), e.message]}
+            errors = {"area_id_map_url": [_("Failed to download the area id map csv file."), str(e)]}
             return __summary_stage(data, errors, harvest_source=harvest_source)
         try:
             csv_stream = StringIO(area_csv.text)
@@ -286,8 +285,8 @@ def __save_or_update_harvest_source(data, harvest_source=None):
         else:
             return __save_harvest_source(data)
     except Exception as e:
-        log.exception(e.message)
-        h.flash_error('Error while saving the harvest source: {}'.format(e.message))
+        log.exception(str(e))
+        h.flash_error('Error while saving the harvest source: {}'.format(str(e)))
         return __summary_stage(data, harvest_source=harvest_source)
 
 
@@ -482,7 +481,7 @@ def __data_initialization(edit_configuration=False):
                 columns_[c_id_]['operation'] = operations.SUBTRACT
 
         columns_list_ = []
-        for c_id, c_details in six.iteritems(columns_):
+        for c_id, c_details in columns_.items():
             c_details['id'] = c_id
             columns_list_.append(c_details)
 
@@ -506,7 +505,7 @@ def __get_pt_configs(data):
     from .config.column_configs_template import TARGET_TYPES
     data['column_config'] = TARGET_TYPES
     target_types_ = [{'text': type_d['name'], 'value': type_id}
-                     for type_id, type_d in six.iteritems(TARGET_TYPES)]
+                     for type_id, type_d in TARGET_TYPES.items()]
     data['target_types'] = target_types_
 
 

--- a/ckanext/dhis2harvester/ui_blueprint.py
+++ b/ckanext/dhis2harvester/ui_blueprint.py
@@ -284,9 +284,9 @@ def __save_or_update_harvest_source(data, harvest_source=None):
             return __update_harvest_source(data)
         else:
             return __save_harvest_source(data)
-    except Exception as e:
-        log.exception(str(e))
-        h.flash_error('Error while saving the harvest source: {}'.format(str(e)))
+    except Exception:
+        log.exception("Error while saving the harvest source")
+        h.flash_error(_('Error while saving the harvest source.'))
         return __summary_stage(data, harvest_source=harvest_source)
 
 

--- a/ckanext/dhis2harvester/ui_blueprint.py
+++ b/ckanext/dhis2harvester/ui_blueprint.py
@@ -89,7 +89,7 @@ def pivot_tables_refresh(harvest_source_id):
     data = request.form.to_dict()
     # Both view and submit are POST requests due to ckan-harvest flow
     # if data is empty display the form
-    if data:
+    if data and data.get('dhis2_url'):
         dhis2_conn_ = __get_dhis_conn(request.form)
         errors = _validate_dhis2_connection(dhis2_conn_)
         if errors:
@@ -115,7 +115,7 @@ def pivot_tables_refresh(harvest_source_id):
             log.error("An error occurred: {}".format(str(e)))
             raise e
         _flash_source_refresh_success()
-        return h.redirect_to('harvest_admin', id=harvester_name)
+        return h.redirect_to('harvester.admin', id=harvester_name)
     else:
         data = {}
         (dhis2_url, dhis2_api_version, dhis2_auth_token) = __get_dhis2_connection_details_from_harvest_source(
@@ -124,7 +124,7 @@ def pivot_tables_refresh(harvest_source_id):
             try:
                 harvest_utils.create_job(harvest_source_id)
                 _flash_source_refresh_success()
-                return h.redirect_to('harvest_admin', id=harvester_name)
+                return h.redirect_to('harvester.admin', id=harvester_name)
             except ValidationError as e:
                 log.error("An error occurred: {}".format(str(e)))
         data['dhis2_url'] = dhis2_url
@@ -244,7 +244,7 @@ def __save_harvest_source(data):
         raise e
     log.info("Harvest source {} created".format(harvester_name))
 
-    return h.redirect_to('harvest_admin', id=harvester_name)
+    return h.redirect_to('harvester.admin', id=harvester_name)
 
 
 def __update_harvest_source(data):
@@ -254,7 +254,7 @@ def __update_harvest_source(data):
     except ValidationError as e:
         log.error("An error occurred: {}".format(str(e.error_dict)))
         raise e
-    return h.redirect_to('harvest_admin', id=harvester_name)
+    return h.redirect_to('harvester.admin', id=harvester_name)
 
 
 def __save_or_update_harvest_source(data, harvest_source=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+requests
+six

--- a/test.ini
+++ b/test.ini
@@ -13,6 +13,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
+ckan.plugins = harvest dhis2harvester_plugin dhis2_pivot_tables_harvester
 
 
 # Logging configuration


### PR DESCRIPTION
## Summary

Upgrades the DHIS2 harvester extension to run on CKAN 2.10 / 2.11 and Python 3.10, replacing the previous 2.9 / Python 3.9 baseline. The upgrade covers the runtime code, Jinja templates, CI, and a set of latent Python 3 bugs.

## What changed

**Runtime / Python 3 cleanup**
- Remove all remaining `six` usage (`six.iteritems`, `six.text_type`, `six.StringIO`) — replace with native Python 3 equivalents.
- Fix broken Py3 exception paths: `e.message` no longer exists on `Exception`, so several `_save_object_error` / `flash_error` handlers were silently dead before. They now use standard `str(e)` semantics and route full tracebacks through `log.exception`.
- Fix a typo (`_save_object_error_error` → `_save_object_error`) that made several harvester error paths unreachable.
- `dhis2_api`: add fallback for DHIS2 >= 2.37 pivot-table endpoint changes, tidy auth header handling.
- `ui_blueprint`: require `dhis2_url` before treating a POST as a submission so a blank form POST renders the form instead of failing validation.

**Templates**
- Update all Flask-style dotted route names (`harvest.search`, `harvest.read`, `harvester.admin`, etc.) for compatibility with CKAN 2.11 / ckanext-harvest.
- Bootstrap 5 migration: button class updates, grid class updates, `data-bs-*` attributes, dropdown markup, `.hidden` helper re-added in CSS.

**CI**
- Matrix-test against CKAN 2.10 and 2.11 (`ckan/ckan-dev:2.10-py3.10`, `ckan/ckan-dev:2.11-py3.10`) on Python 3.10.
- Install `ckanext-harvest` from a pinned commit SHA on the `fjelltopp` fork (immutable — safe against force-pushes).
- Run `harvester initdb` before tests so the harvest tables exist.
- Bump action versions and add `requirements.txt` with runtime deps.

**Security hardening (in this branch)**
- Harvest gather/object errors no longer embed raw exception text (which may contain URLs, tokens, or upstream server detail) in messages shown in the harvest admin UI. Full tracebacks are preserved server-side via `log.exception`.
- The flash error on harvest source save no longer leaks the exception string to the end user.
- The CI `ckanext-harvest` dependency is pinned to a commit SHA instead of a mutable branch ref.

## Test plan

- [ ] CI green on both `ckan-2.10` and `ckan-2.11` matrix legs.
- [ ] Create a DHIS2 harvest source end-to-end (DHIS2 credentials → pivot table selection → column configuration → save) on a CKAN 2.11 instance.
- [ ] Run a harvest job and confirm pivot-table data imports successfully.
- [ ] Trigger an error path (bad DHIS2 URL, bad token) and confirm:
  - the harvest admin UI shows a sanitized error message (no tokens / tracebacks);
  - the server log contains the full `log.exception` traceback.
- [ ] Edit an existing harvest source and confirm redirects go to the new `harvester.admin` route.
- [ ] Visual smoke-test the pivot-table configuration pages under Bootstrap 5 (buttons, dropdowns, grid).
