### PR TITLE
Fix: Add config for DHIS2 version 2.40

### DIFF
--- a/ckanext/dhis2harvester/dhis2_api.py
+++ b/ckanext/dhis2harvester/dhis2_api.py
@@ -11,6 +11,32 @@ from ckanext.dhis2harvester import request_util
 log = logging.getLogger(__name__)
 
 API_CONFIG = {
+    40: {
+        # ADR does not support chunking in DHIS2 metadata fetch, some DHIS2 have >8000 pivot tables
+        # as a workaround we fetch pivot tables with names matching UNAIDS or ONUSIDA
+        "PIVOT_TABLES_RESOURCE": 'visualizations?type=PIVOT_TABLE&'
+                                 'fields=id,displayName~rename(name),created,lastUpdated,access,title,description,user&'
+                                 'rootJunction=OR&filter=name:like:UNAIDS&filter=name:like:ONUSIDA&pageSize=200',
+        "PIVOT_TABLES_KEY_NAME": "visualizations",
+        "PIVOT_TABLES_CSV_RESOURCE": 'analytics.csv?'
+                                     'dimension=dx:{data_elements}&'
+                                     'dimension=pe:{periods}&'
+                                     'dimension=co&'
+                                     'dimension=ou:{organisation_units}&'
+                                     'displayProperty=NAME&'
+                                     'hierarchyMeta=true&'
+                                     'outputIdScheme=UID',
+        "PIVOT_TABLES_CSV_INDICATOR_RESOURCE": 'analytics.csv?'
+                                               'dimension=dx:{indicators}&'
+                                               'dimension=pe:{periods}&'
+                                               'dimension=ou:{organisation_units}&'
+                                               'displayProperty=NAME&'
+                                               'hierarchyMeta=true&'
+                                               'outputIdScheme=UID',
+        "PIVOT_TABLE_KEYS": ["lastUpdated", "created", "id", "name"],
+        "SECURITY_LOGIN_ACTION": 'dhis-web-commons-security/login.action',
+        "ORG_UNIT_RESOURCE": "organisationUnits?paging=false&fields=id,name"
+    },
     37: {
         # ADR does not support chunking in DHIS2 metadata fetch, some DHIS2 have >8000 pivot tables
         # as a workaround we fetch pivot tables with names matching UNAIDS or ONUSIDA
@@ -106,7 +132,7 @@ class Dhis2Connection(object):
     def __setup_api_config(self, api_version=None):
         if not api_version:
             api_version = DEFAULT_API_VERSION
-        for version in reversed(sorted(API_CONFIG.keys())):
+        for version in sorted(API_CONFIG.keys(), reverse=True):
             if int(api_version) >= version:
                 config = API_CONFIG[version]
                 break


### PR DESCRIPTION
## Description

This PR updates the config to with with DHIS version 2.40.

Specifically we've noticed when configuring a new DHIS2 harvester source we're getting an error "Failed to get pivot tables information" after entering credentials.

So I had a look and I think this is because the API endpoint to fetch pivot tables is receiving an error. I called the endpoint `https://snisrdc.com/api/visualizations.json?type=PIVOT_TABLE&fields=id,displayName~rename(name),created,lastUpdated,access,description,user&rootJunction=OR&filter=name:like:UNAIDS&filter=name:like:ONUSIDA&pageSize=200` and got a 403 error. I tried simplifying this query bit by bit and found that if we drop the `rename` that everything works. 

However by chance, when reading the docs, I also noticed that we can call this and drop the `.json` in the API call and keep the rename and everything works. Now the `.json` route is still supported and nothing in the docs to suggest it should work any diferently. So I really am not sure why this fixes it, without looking deeply through the source code. It does fix it for v40. But we should probably check whether we should set this for v 38 and/or 39 too. I'll see if Ian has any countries using these versions.

## Testing (delete if not applicable)

I'm actually not sure what the best way to test this is, I can't really see any unit tests here so is it best just to deploy this to dev? Or can we run this up locally without too much pain? What do you think?
